### PR TITLE
Fix bugs for different between frontier and eth

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -250,6 +250,28 @@ defmodule EthereumJSONRPC.Transaction do
     end
   end
 
+  # Geth pending transactions don't include `r,s,v` transaction fields.
+  def elixir_to_params(
+      %{
+        "blockHash" => _,
+        "blockNumber" => _,
+        "from" => _,
+        "gas" => _,
+        "gasPrice" => _,
+        "hash" => _,
+        "input" => _,
+        "nonce" => _,
+        "to" => _,
+        "transactionIndex" => _,
+        "value" => _
+      } = transaction
+    ) do
+    transaction
+    |> Map.merge(%{"r" => 0, "s" => 0, "v" => 0})
+    |> elixir_to_params()
+  end
+
+
   @doc """
   Extracts `t:EthereumJSONRPC.hash/0` from transaction `params`
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -252,25 +252,24 @@ defmodule EthereumJSONRPC.Transaction do
 
   # Geth pending transactions don't include `r,s,v` transaction fields.
   def elixir_to_params(
-      %{
-        "blockHash" => _,
-        "blockNumber" => _,
-        "from" => _,
-        "gas" => _,
-        "gasPrice" => _,
-        "hash" => _,
-        "input" => _,
-        "nonce" => _,
-        "to" => _,
-        "transactionIndex" => _,
-        "value" => _
-      } = transaction
-    ) do
+        %{
+          "blockHash" => _,
+          "blockNumber" => _,
+          "from" => _,
+          "gas" => _,
+          "gasPrice" => _,
+          "hash" => _,
+          "input" => _,
+          "nonce" => _,
+          "to" => _,
+          "transactionIndex" => _,
+          "value" => _
+        } = transaction
+      ) do
     transaction
     |> Map.merge(%{"r" => 0, "s" => 0, "v" => 0})
     |> elixir_to_params()
   end
-
 
   @doc """
   Extracts `t:EthereumJSONRPC.hash/0` from transaction `params`

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -28,16 +28,17 @@ defmodule Explorer.Chain.Cache.Transaction do
   def estimated_count do
     cached_value = __MODULE__.get_count()
 
-    result_estimated_count = if is_nil(cached_value) do
-      %Postgrex.Result{rows: [[rows]]} =
-        SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
+    result_estimated_count =
+      if is_nil(cached_value) do
+        %Postgrex.Result{rows: [[rows]]} =
+          SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
 
-      rows
-    else
-      cached_value
-    end
+        rows
+      else
+        cached_value
+      end
 
-    if result_estimated_count < 100000 do
+    if result_estimated_count < 100_000 do
       # use no estimate count when the tx is less
       %Postgrex.Result{rows: [[rows]]} =
         SQL.query!(Repo, "SELECT count(*) AS estimate FROM public.transactions WHERE block_number>0")

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -28,13 +28,23 @@ defmodule Explorer.Chain.Cache.Transaction do
   def estimated_count do
     cached_value = __MODULE__.get_count()
 
-    if is_nil(cached_value) do
+    result_estimated_count = if is_nil(cached_value) do
       %Postgrex.Result{rows: [[rows]]} =
         SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
 
       rows
     else
       cached_value
+    end
+
+    if result_estimated_count < 100000 do
+      # use no estimate count when the tx is less
+      %Postgrex.Result{rows: [[rows]]} =
+        SQL.query!(Repo, "SELECT count(*) AS estimate FROM public.transactions WHERE block_number>0")
+
+      rows
+    else
+      result_estimated_count
     end
   end
 


### PR DESCRIPTION
Fix some bugs cause by different between frontier and eth :

- fix no match tx format from the txpool rpc api.
- fix tx count not right by estimated_count, not use the estimated_count when tx count not too much.
- merge the change from moonbeam fork to blockscout
